### PR TITLE
Docs/Get proof docstrings

### DIFF
--- a/contracts/Merkle.sol
+++ b/contracts/Merkle.sol
@@ -14,7 +14,16 @@ library Merkle {
 
     /// @dev calculates a root hash associated with a merkle proof
     /// @param proof array of proof hashes
-    /// @param key index of the leaf element list
+    /// @param key index of the leaf element list.
+    ///        this key indicates the specific position of the leaf
+    ///        in the merkle tree. It will be used to know if the
+    ///        node that will be hashed along with the proof node
+    ///        is placed on the right or the left of the current
+    ///        tree level. That is achieved by doing the modulo of
+    ///        the current key/position. A new level of nodes will
+    ///        be evaluated after that, and the new left or right
+    ///        position is obtained by doing the same operation, 
+    ///        after dividing the key/position by two.
     /// @param leaf the leaf element to verify on the set.
     /// @return the hash of the merkle proof. Should match the merkle root if the proof is valid
 


### PR DESCRIPTION
I added some comments of what I understand the `getProofRootHash` function does. Please check that the explanation is accurate (and understandable).

Should we add a link to an image like the one below somewhere in the code to show an example? Or is it good just like this?
![image](https://user-images.githubusercontent.com/4080111/55256924-2cd2b580-523d-11e9-997f-a0455d64175a.png)
