### PR TITLE
Refactor/Decrease approval fix

### DIFF
--- a/contracts/StandardToken.sol
+++ b/contracts/StandardToken.sol
@@ -98,12 +98,7 @@ contract StandardToken is IERC20 {
     }
 
     function decreaseApproval(address _spender, uint _subtractedValue) public returns (bool) {
-        uint oldValue = allowed[msg.sender][_spender];
-        if (_subtractedValue > oldValue) {
-            allowed[msg.sender][_spender] = 0;
-        } else {
-            allowed[msg.sender][_spender] = SafeMath.sub(oldValue, _subtractedValue);
-        }
+        allowed[msg.sender][_spender] = SafeMath.sub(allowed[msg.sender][_spender], _subtractedValue);
         emit Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
         return true;
     }


### PR DESCRIPTION
I removed the `if (_subtractedValue > oldValue) { allowed[msg.sender][_spender] = 0; } `.
`SafeMath` already checks that `_subtractedValue > oldValue`, and I think that's better to throw an error if you're trying to subtract more balance than the one you actually have.