### PR TITLE
Docs/Added warning in registerPayment function

### DIFF
--- a/contracts/Payments.sol
+++ b/contracts/Payments.sol
@@ -377,13 +377,14 @@ contract Payments is Accounts {
         require(len >= 2, "payData length should be >= 2");
         require(uint8(payData[0]) == PAY_DATA_HEADER_MARKER, "payData header missing");
         uint bytesPerId = uint(payData[1]);
-        require(bytesPerId > 0, "bytes per Id should be positive");
+        require(bytesPerId > 0, "second byte of payData should be positive");
 
         // substract header bytes
         len -= 2;
 
         // remaining bytes should be a multiple of bytesPerId
-        require(len % bytesPerId == 0, "payData length is invalid");
+        require(len % bytesPerId == 0,
+        "payData length is invalid, all payees must have same amount of bytes (payData[1])");
 
         // calculate number of records
         return SafeMath.div(len, bytesPerId);


### PR DESCRIPTION
I just added _"DO NOT use previously used locking keys, since an attacker could realize that by comparing key hashes"_ on the `lockingKeyHash` param description, of the `registerPayment` method. [(HERE)](https://github.com/wibsonorg/BatchPayments/compare/rc2...am-warn-reuse-keys?expand=1#diff-a7e5b53093e738bba16c57bdfdc577c3R85)

I think it would be more helpful to have this kind of "warning" in notary environments more than in the smart contract itself, since those pieces are the ones that are actually creating and sending the lock keys.