### PR TITLE
Git attributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
`npm run test`  won't work on docker on a windows hosts because crlf line ending added by windows git. 
This PR adds .gitattributes files to tell git to avoid messing with .sh files