### PR TITLE
fix crlf problems with .sh files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sh text eol=lf


### PR DESCRIPTION
There is a compatibility issue with git on a windows host with a docker guest. CRLF line ending is added to text files and shell scripts fail.
This PR adds a gitattributes file that instructs git to avoid messing with shell scripts
